### PR TITLE
🚀 Deploy : 이력서 작성 폼 페이지를 구현하였습니다

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "react-dom": "^19.2.0",
     "react-hook-form": "^7.71.2",
     "react-router-dom": "^7.13.1",
+    "react-textarea-autosize": "^8.5.9",
     "tailwindcss": "^4.2.1",
+    "zod": "^4.3.6",
     "zustand": "^5.0.11"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,15 @@ importers:
       react-router-dom:
         specifier: ^7.13.1
         version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react-textarea-autosize:
+        specifier: ^8.5.9
+        version: 8.5.9(@types/react@19.2.14)(react@19.2.4)
       tailwindcss:
         specifier: ^4.2.1
         version: 4.2.1
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
       zustand:
         specifier: ^5.0.11
         version: 5.0.11(@types/react@19.2.14)(react@19.2.4)
@@ -169,6 +175,10 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
@@ -1654,6 +1664,12 @@ packages:
       react-dom:
         optional: true
 
+  react-textarea-autosize@8.5.9:
+    resolution: {integrity: sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
@@ -1813,6 +1829,33 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  use-composed-ref@1.4.0:
+    resolution: {integrity: sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-isomorphic-layout-effect@1.2.1:
+    resolution: {integrity: sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-latest@1.3.0:
+    resolution: {integrity: sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   vite@7.3.1:
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
@@ -2012,6 +2055,8 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/runtime@7.29.2': {}
 
   '@babel/template@7.28.6':
     dependencies:
@@ -3347,6 +3392,15 @@ snapshots:
     optionalDependencies:
       react-dom: 19.2.4(react@19.2.4)
 
+  react-textarea-autosize@8.5.9(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      '@babel/runtime': 7.29.2
+      react: 19.2.4
+      use-composed-ref: 1.4.0(@types/react@19.2.14)(react@19.2.4)
+      use-latest: 1.3.0(@types/react@19.2.14)(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+
   react@19.2.4: {}
 
   require-directory@2.1.1: {}
@@ -3505,6 +3559,25 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-composed-ref@1.4.0(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  use-isomorphic-layout-effect@1.2.1(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  use-latest@1.3.0(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      use-isomorphic-layout-effect: 1.2.1(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2):
     dependencies:

--- a/src/components/resume/CreateButton.tsx
+++ b/src/components/resume/CreateButton.tsx
@@ -4,12 +4,12 @@ interface CreateButtonProps {
   icon: string;
   title: string;
   sub: string;
-  path?: string;
+  path: string;
 }
 
-const CreateButton = ({ icon, title, sub }: CreateButtonProps) => {
+const CreateButton = ({ icon, title, sub, path }: CreateButtonProps) => {
   return (
-    <Link to="/">
+    <Link to={path}>
       <div className="w-full h-75 relative">
         <div className="flex w-full h-full items-center justify-center relative">
           <div className="text-center">

--- a/src/components/resume/ResumeItem.tsx
+++ b/src/components/resume/ResumeItem.tsx
@@ -2,6 +2,7 @@ import { MoreVertical } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import clsx from 'clsx';
+import { useResumeItemMenuStore } from '@/store/useResumeItemMenuStore';
 
 interface ResumeItemProps {
   title: string;
@@ -14,11 +15,14 @@ const ResumeItem = ({ title, memo, updatedAt }: ResumeItemProps) => {
   const menuRef = useRef<HTMLButtonElement | null>(null);
   const navigate = useNavigate();
 
+  const { isAnyMenuOpen, setIsAnyMenuOpen } = useResumeItemMenuStore();
+
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
       if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
         setIsOpen((value) => {
           if (value > 0) {
+            setIsAnyMenuOpen(false);
             return value - 1;
           } else {
             return value;
@@ -28,15 +32,18 @@ const ResumeItem = ({ title, memo, updatedAt }: ResumeItemProps) => {
     };
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
+  }, [setIsAnyMenuOpen]);
 
   return (
-    <div className="w-full h-75 relative">
+    <div className="w-full h-64 xl:h-75 relative">
       <div
         className="w-full h-full rounded-2xl p-7 bg-blue-50 border-2 border-blue-100 hover:border-blue-200 z-0"
         onClick={() => {
-          if (!isOpen) {
+          if (!isAnyMenuOpen && !isOpen) {
             navigate('/');
+          } else {
+            setIsOpen((value) => Math.max(0, value - 1));
+            setIsAnyMenuOpen(false);
           }
         }}
       >
@@ -48,8 +55,10 @@ const ResumeItem = ({ title, memo, updatedAt }: ResumeItemProps) => {
         className="absolute top-5 right-7 rounded-2xl py-2 px-0.5 hover:bg-black/5 z-10"
         onClick={() => {
           if (isOpen > 1) {
+            setIsAnyMenuOpen(false);
             setIsOpen(0);
           } else {
+            setIsAnyMenuOpen(true);
             setIsOpen(2);
           }
         }}

--- a/src/components/resumeForm/AddLanguageTest.tsx
+++ b/src/components/resumeForm/AddLanguageTest.tsx
@@ -1,0 +1,63 @@
+import type { ResumeFormInputs } from '@/type/ResumeFormType';
+import { Trash2 } from 'lucide-react';
+import { useFieldArray, useFormContext } from 'react-hook-form';
+
+const AddLanguageTest = ({ fieldIndex }: { fieldIndex: number }) => {
+  const { register, control } = useFormContext<ResumeFormInputs>();
+  const { fields, append, remove } = useFieldArray({
+    control: control,
+    name: `language.${fieldIndex}.test`,
+  });
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => {
+          append({ testName: '', score: '', date: null });
+        }}
+        className="p-2 hover:bg-black/5"
+      >
+        +어학시험 추가
+      </button>
+      {fields.map((field, index) => (
+        <div key={field.id} className="w-full group relative p-2 rounded-xl hover:bg-black/5">
+          <div className="flex gap-1">
+            <input
+              {...register(`language.${fieldIndex}.test.${index}.testName`)}
+              type="text"
+              placeholder="시험명"
+            />
+            <input
+              {...register(`language.${fieldIndex}.test.${index}.score`)}
+              type="text"
+              placeholder="점수/등급"
+            />
+          </div>
+          <input
+            {...register(`language.${fieldIndex}.test.${index}.date`, { valueAsDate: true })}
+            type="date"
+          />
+          <button
+            type="button"
+            onClick={() => {
+              if (fields.length === 1) {
+                append({
+                  testName: '',
+                  score: '',
+                  date: null,
+                });
+              }
+              remove(index);
+            }}
+            className="absolute top-2 right-2 w-8 h-8 p-1.5 hidden group-hover:flex items-center shadow-sm justify-center bg-white rounded-sm hover:bg-black/5"
+          >
+            <Trash2 className="text-black" />
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default AddLanguageTest;

--- a/src/components/resumeForm/CharacterCounter.tsx
+++ b/src/components/resumeForm/CharacterCounter.tsx
@@ -1,0 +1,34 @@
+import {
+  useWatch,
+  type Control,
+  type FieldPath,
+  type FieldValues,
+  type PathValue,
+} from 'react-hook-form';
+
+interface CharacterCounterProps<T extends FieldValues> {
+  control: Control<T>;
+  name: FieldPath<T>;
+  limit: number;
+}
+
+const CharacterCounter = <T extends FieldValues>({
+  control,
+  name,
+  limit,
+}: CharacterCounterProps<T>) => {
+  const value = useWatch({
+    control,
+    name,
+    defaultValue: '' as PathValue<T, FieldPath<T>>,
+  });
+
+  return (
+    <p className="hidden group-has-[textarea:focus]:block mt-10 w-full text-end">
+      {value.length}
+      <span className="text-black/40"> / {limit}</span>
+    </p>
+  );
+};
+
+export default CharacterCounter;

--- a/src/components/resumeForm/ResumeFormAdditionalInfo.tsx
+++ b/src/components/resumeForm/ResumeFormAdditionalInfo.tsx
@@ -1,0 +1,104 @@
+import type { AdditionalInfoType, ResumeFormInputs } from '@/type/ResumeFormType';
+import { Trash2 } from 'lucide-react';
+import { useFieldArray, useFormContext } from 'react-hook-form';
+import TextAreaAutosize from 'react-textarea-autosize';
+import CharacterCounter from './CharacterCounter';
+
+const ResumeFormAdditionalInfo = () => {
+  const { register, control } = useFormContext<ResumeFormInputs>();
+  const { fields, append, remove } = useFieldArray({
+    control: control,
+    name: 'additionalInfo',
+  });
+
+  const typeOption: { value: AdditionalInfoType; label: string }[] = [
+    { value: '수상', label: '수상' },
+    { value: '자격증', label: '자격증' },
+    { value: '활동', label: '활동' },
+  ];
+
+  return (
+    <div className="w-full mt-20">
+      <label className="text-xl ml-2">수상/자격증/기타</label>
+      <div className="w-full mt-3 ml-2 h-px bg-black/40" />
+      {fields.map((field, index) => (
+        <div
+          key={field.id}
+          className="w-full relative flex mt-5 group has-focus:outline-2 outline-blue-200 rounded-lg p-3 hover:outline-2"
+        >
+          <div className="flex-1">
+            <input
+              {...register(`additionalInfo.${index}.name`)}
+              type="text"
+              placeholder="활동명"
+              className="w-full outline-none resize-none"
+            />
+            <div className="w-full flex gap-3">
+              <input {...register(`additionalInfo.${index}.date`)} type="date" />
+              <select
+                {...register(`additionalInfo.${index}.type`)}
+                defaultValue=""
+                className="py-2 px-1 rounded-md bg-white hover:bg-black/10 appearance-none [text-align-last:center]"
+              >
+                <option value="" disabled hidden>
+                  타입
+                </option>
+                {typeOption.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <TextAreaAutosize
+              {...register(`additionalInfo.${index}.description`)}
+              maxLength={1000}
+              placeholder="description"
+              className="w-full outline-none mt-5 resize-none"
+            />
+            <CharacterCounter
+              control={control}
+              name={`additionalInfo.${index}.description`}
+              limit={1000}
+            />
+          </div>
+          <div className="absolute -bottom-14 left-[48%] w-14 h-14 p-2">
+            <button
+              type="button"
+              onClick={() => {
+                append({
+                  name: '',
+                  date: null,
+                  type: undefined,
+                  description: '',
+                });
+              }}
+              className="w-full h-full rounded-full bg-blue-100 text-blue-500 text-3xl text-center justify-center hidden group-hover:flex hover:bg-blue-200"
+            >
+              +
+            </button>
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              if (fields.length === 1) {
+                append({
+                  name: '',
+                  date: null,
+                  type: undefined,
+                  description: '',
+                });
+              }
+              remove(index);
+            }}
+            className="absolute top-4 right-4 w-8 h-8 p-1.5 hidden group-hover:flex items-center justify-center bg-blue-100 rounded-sm hover:bg-blue-200"
+          >
+            <Trash2 className="text-blue-600" />
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ResumeFormAdditionalInfo;

--- a/src/components/resumeForm/ResumeFormEducation.tsx
+++ b/src/components/resumeForm/ResumeFormEducation.tsx
@@ -1,0 +1,89 @@
+import type { ResumeFormInputs } from '@/type/ResumeFormType';
+import { Trash2 } from 'lucide-react';
+import { useFieldArray, useFormContext } from 'react-hook-form';
+import CharacterCounter from './CharacterCounter';
+import TextAreaAutosize from 'react-textarea-autosize';
+
+const ResumeFormEducation = () => {
+  const { register, control } = useFormContext<ResumeFormInputs>();
+  const { fields, append, remove } = useFieldArray({
+    control: control,
+    name: 'education',
+  });
+
+  return (
+    <div className="w-full mt-20">
+      <label className="text-xl ml-2">학력</label>
+      {fields.map((field, index) => (
+        <div
+          key={field.id}
+          className="w-full relative flex mt-5 group has-focus:outline-2 outline-blue-200 rounded-lg p-3 hover:outline-2"
+        >
+          <div className="flex-1">
+            <input
+              {...register(`education.${index}.name`)}
+              type="text"
+              placeholder="학교 및 기관 명"
+              className="w-full outline-none resize-none"
+            />
+            <div className="w-full flex">
+              <input
+                {...register(`education.${index}.period.startDate`, { valueAsDate: true })}
+                type="date"
+              />
+              <p>-</p>{' '}
+              <input
+                {...register(`education.${index}.period.endDate`, { valueAsDate: true })}
+                type="date"
+              />
+            </div>
+            <TextAreaAutosize
+              {...register(`education.${index}.description`)}
+              maxLength={1000}
+              placeholder="이수 과목 또는 연구 내용을 작성해보세요."
+              className="w-full outline-none mt-5 resize-none"
+            />
+            <CharacterCounter
+              control={control}
+              name={`education.${index}.description`}
+              limit={1000}
+            />
+          </div>
+          <div className="absolute -bottom-14 left-[48%] w-14 h-14 p-2">
+            <button
+              type="button"
+              onClick={() => {
+                append({
+                  name: '',
+                  period: { startDate: null, endDate: null },
+                  description: '',
+                });
+              }}
+              className="w-full h-full rounded-full bg-blue-100 text-blue-500 text-3xl text-center justify-center hidden group-hover:flex hover:bg-blue-200"
+            >
+              +
+            </button>
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              remove(index);
+              if (fields.length === 1) {
+                append({
+                  name: '',
+                  period: { startDate: null, endDate: null },
+                  description: '',
+                });
+              }
+            }}
+            className="absolute top-4 right-4 w-8 h-8 p-1.5 hidden group-hover:flex items-center justify-center bg-blue-100 rounded-sm hover:bg-blue-200"
+          >
+            <Trash2 className="text-blue-600" />
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ResumeFormEducation;

--- a/src/components/resumeForm/ResumeFormLanguage.tsx
+++ b/src/components/resumeForm/ResumeFormLanguage.tsx
@@ -1,0 +1,92 @@
+import type { LanguageLevelType, ResumeFormInputs } from '@/type/ResumeFormType';
+import { Trash2 } from 'lucide-react';
+import { useFieldArray, useFormContext } from 'react-hook-form';
+import AddLanguageTest from './AddLanguageTest';
+
+const ResumeFormLanguage = () => {
+  const { register, control } = useFormContext<ResumeFormInputs>();
+  const { fields, append, remove } = useFieldArray({
+    control: control,
+    name: 'language',
+  });
+
+  const typeOption: { value: LanguageLevelType; label: string }[] = [
+    { value: '유창함', label: '유창함' },
+    { value: '고급 비즈니스 레벨', label: '고급 비즈니스 레벨' },
+    { value: '비즈니스 레벨', label: '비즈니스 레벨' },
+    { value: '일상 회화', label: '일상 회화' },
+  ];
+
+  return (
+    <div className="w-full mt-20">
+      <label className="text-xl ml-2">언어</label>
+      <div className="w-full mt-3 ml-2 h-px bg-black/40" />
+      {fields.map((field, index) => (
+        <div
+          key={field.id}
+          className="w-full relative flex mt-5 group has-focus:outline-2 outline-blue-200 rounded-lg p-3 hover:outline-2"
+        >
+          <div className="flex-1">
+            <div className="w-full flex">
+              <input
+                {...register(`language.${index}.name`)}
+                type="text"
+                placeholder="언어명"
+                className="w-1/3 outline-none resize-none"
+              />
+              <select
+                {...register(`language.${index}.level`)}
+                defaultValue=""
+                className="py-2 px-1 rounded-md bg-white hover:bg-black/10 appearance-none [text-align-last:center]"
+              >
+                <option value="" disabled hidden>
+                  수준
+                </option>
+                {typeOption.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <AddLanguageTest fieldIndex={index} />
+          </div>
+
+          <div className="absolute -bottom-14 left-[48%] w-14 h-14 p-2">
+            <button
+              type="button"
+              onClick={() => {
+                append({
+                  name: '',
+                  level: undefined,
+                  test: [],
+                });
+              }}
+              className="w-full h-full rounded-full bg-blue-100 text-blue-500 text-3xl text-center justify-center hidden group-hover:flex hover:bg-blue-200"
+            >
+              +
+            </button>
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              if (fields.length === 1) {
+                append({
+                  name: '',
+                  level: undefined,
+                  test: [],
+                });
+              }
+              remove(index);
+            }}
+            className="absolute top-4 right-4 w-8 h-8 p-1.5 hidden group-hover:flex items-center justify-center bg-blue-100 rounded-sm hover:bg-blue-200"
+          >
+            <Trash2 className="text-blue-600" />
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ResumeFormLanguage;

--- a/src/components/resumeForm/ResumeFormPortfolio.tsx
+++ b/src/components/resumeForm/ResumeFormPortfolio.tsx
@@ -1,0 +1,69 @@
+import type { ResumeFormInputs } from '@/type/ResumeFormType';
+import { Trash2 } from 'lucide-react';
+import { useFieldArray, useFormContext } from 'react-hook-form';
+
+const ResumeFormWorkPortfolio = () => {
+  const { register, control } = useFormContext<ResumeFormInputs>();
+  const { fields, append, remove } = useFieldArray({
+    control: control,
+    name: 'portfolio',
+  });
+
+  return (
+    <div className="w-full mt-20">
+      <label className="text-xl ml-2">포트폴리오</label>
+      {fields.map((field, index) => (
+        <div
+          key={field.id}
+          className="w-full relative flex mt-5 group has-focus:outline-2 outline-blue-200 rounded-lg p-3 hover:outline-2"
+        >
+          <div className="flex-1">
+            <input
+              {...register(`portfolio.${index}.name`)}
+              type="text"
+              placeholder="포트폴리오명을 입력해 주세요."
+              className="w-full outline-none resize-none"
+            />
+            <input
+              {...register(`portfolio.${index}.url`)}
+              type="text"
+              placeholder="URL주소를 입력해 주세요."
+              className="w-full outline-none resize-none"
+            />
+          </div>
+          <div className="absolute -bottom-14 left-[48%] w-14 h-14 p-2">
+            <button
+              type="button"
+              onClick={() => {
+                append({
+                  name: '',
+                  url: '',
+                });
+              }}
+              className="w-full h-full rounded-full bg-blue-100 text-blue-500 text-3xl text-center justify-center hidden group-hover:flex hover:bg-blue-200"
+            >
+              +
+            </button>
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              if (fields.length === 1) {
+                append({
+                  name: '',
+                  url: '',
+                });
+              }
+              remove(index);
+            }}
+            className="absolute top-4 right-4 w-8 h-8 p-1.5 hidden group-hover:flex items-center justify-center bg-blue-100 rounded-sm hover:bg-blue-200"
+          >
+            <Trash2 className="text-blue-600" />
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ResumeFormWorkPortfolio;

--- a/src/components/resumeForm/ResumeFormProfile.tsx
+++ b/src/components/resumeForm/ResumeFormProfile.tsx
@@ -1,0 +1,24 @@
+import TextAreaAutosize from 'react-textarea-autosize';
+import { useFormContext } from 'react-hook-form';
+import type { ResumeFormInputs } from '@/type/ResumeFormType';
+import CharacterCounter from './CharacterCounter';
+
+const ResumeFormProfile = () => {
+  const { register, control } = useFormContext<ResumeFormInputs>();
+  return (
+    <div className="w-full group has-focus:outline-2 outline-blue-200 rounded-lg p-3 hover:outline-2">
+      <label htmlFor="profile" className="text-xl">
+        간단 소개
+      </label>
+      <TextAreaAutosize
+        id="profile"
+        {...register('profile')}
+        maxLength={5000}
+        className="w-full outline-none mt-5 resize-none min-h-40"
+      />
+      <CharacterCounter control={control} name="profile" limit={5000} />
+    </div>
+  );
+};
+
+export default ResumeFormProfile;

--- a/src/components/resumeForm/ResumeFormSkill.tsx
+++ b/src/components/resumeForm/ResumeFormSkill.tsx
@@ -1,0 +1,25 @@
+import TextAreaAutosize from 'react-textarea-autosize';
+import { useFormContext } from 'react-hook-form';
+import type { ResumeFormInputs } from '@/type/ResumeFormType';
+import CharacterCounter from './CharacterCounter';
+
+const ResumeFormSkill = () => {
+  const { register, control } = useFormContext<ResumeFormInputs>();
+  return (
+    <div className="w-full mt-20 group has-focus:outline-2 outline-blue-200 rounded-lg p-3 hover:outline-2">
+      <label htmlFor="skill" className="text-xl">
+        스킬
+      </label>
+      <TextAreaAutosize
+        id="skill"
+        {...register('skill')}
+        maxLength={100}
+        placeholder=", 로 구분하여 작성해주세요."
+        className="w-full outline-none mt-5 resize-none min-h-10"
+      />
+      <CharacterCounter control={control} name="skill" limit={100} />
+    </div>
+  );
+};
+
+export default ResumeFormSkill;

--- a/src/components/resumeForm/ResumeFormTopbar.tsx
+++ b/src/components/resumeForm/ResumeFormTopbar.tsx
@@ -1,0 +1,46 @@
+import { PATH } from '@/router/Path';
+import type { ResumeFormInputs } from '@/type/ResumeFormType';
+import { useFormContext, type SubmitHandler } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+import { ChevronLeft } from 'lucide-react';
+
+const ResumeFormTopbar = () => {
+  const { register, handleSubmit } = useFormContext<ResumeFormInputs>();
+  const navigate = useNavigate();
+
+  const onSubmit: SubmitHandler<ResumeFormInputs> = (data) => {
+    alert(JSON.stringify(data, null, 2));
+  };
+  return (
+    <aside className="bg-white">
+      <div className="w-full min-h-20 flex justify-between items-center gap-10">
+        <button
+          type="button"
+          onClick={() => {
+            navigate(PATH.RESUME);
+          }}
+          className="flex p-2 mx-5 rounded-xl hover:bg-black/5"
+        >
+          <ChevronLeft size={18} className="mt-0.5" />
+          <p>이전 페이지</p>
+        </button>
+        <input
+          {...register('title')}
+          type="text"
+          placeholder="제목을 입력하세요."
+          className="p-3 rounded-xl shadow-inner"
+        />
+        <button
+          type="button"
+          onClick={handleSubmit(onSubmit)}
+          className="py-2 px-3 border mx-5 rounded-xl text-white bg-blue-400 hover:bg-blue-600"
+        >
+          작성 완료
+        </button>
+      </div>
+      <div className="w-full h-px bg-black/5" />
+    </aside>
+  );
+};
+
+export default ResumeFormTopbar;

--- a/src/components/resumeForm/ResumeFormWorkHistory.tsx
+++ b/src/components/resumeForm/ResumeFormWorkHistory.tsx
@@ -1,0 +1,96 @@
+import type { ResumeFormInputs } from '@/type/ResumeFormType';
+import { Trash2 } from 'lucide-react';
+import { useFieldArray, useFormContext } from 'react-hook-form';
+import TextAreaAutosize from 'react-textarea-autosize';
+import CharacterCounter from './CharacterCounter';
+
+const ResumeFormWorkHistory = () => {
+  const { register, control } = useFormContext<ResumeFormInputs>();
+  const { fields, append, remove } = useFieldArray({
+    control: control,
+    name: 'workHistory',
+  });
+
+  return (
+    <div className="w-full mt-20">
+      <label className="text-xl ml-2">경력</label>
+      {fields.map((field, index) => (
+        <div
+          key={field.id}
+          className="w-full relative flex mt-5 group has-focus:outline-2 outline-blue-200 rounded-lg p-3 hover:outline-2"
+        >
+          <div className="flex-1">
+            <input
+              {...register(`workHistory.${index}.companyName`)}
+              type="text"
+              placeholder="회사명"
+              className="w-full outline-none resize-none"
+            />
+            <div className="w-full flex gap-3">
+              <input
+                {...register(`workHistory.${index}.period.startDate`, { valueAsDate: true })}
+                type="date"
+              />
+              <p>-</p>{' '}
+              <input
+                {...register(`workHistory.${index}.period.endDate`, { valueAsDate: true })}
+                type="date"
+              />
+              <input
+                {...register(`workHistory.${index}.position`)}
+                type="text"
+                placeholder="직무"
+              />
+            </div>
+            <TextAreaAutosize
+              {...register(`workHistory.${index}.description`)}
+              maxLength={5000}
+              placeholder="description"
+              className="w-full outline-none mt-5 resize-none"
+            />
+            <CharacterCounter
+              control={control}
+              name={`workHistory.${index}.description`}
+              limit={5000}
+            />
+          </div>
+          <div className="absolute -bottom-14 left-[48%] w-14 h-14 p-2">
+            <button
+              type="button"
+              onClick={() => {
+                append({
+                  companyName: '',
+                  position: '',
+                  period: { startDate: null, endDate: null },
+                  description: '',
+                });
+              }}
+              className="w-full h-full rounded-full bg-blue-100 text-blue-500 text-3xl text-center justify-center hidden group-hover:flex hover:bg-blue-200"
+            >
+              +
+            </button>
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              remove(index);
+              if (fields.length === 1) {
+                append({
+                  companyName: '',
+                  position: '',
+                  period: { startDate: null, endDate: null },
+                  description: '',
+                });
+              }
+            }}
+            className="absolute top-4 right-4 w-8 h-8 p-1.5 hidden group-hover:flex items-center justify-center bg-blue-100 rounded-sm hover:bg-blue-200"
+          >
+            <Trash2 className="text-blue-600" />
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ResumeFormWorkHistory;

--- a/src/router/Path-Router.tsx
+++ b/src/router/Path-Router.tsx
@@ -12,6 +12,7 @@ import Scrap from '@/view/Scrap';
 import Notification from '@/view/Notification';
 import Settings from '@/view/Settings';
 import Auth from '@/view/Auth';
+import ResumeForm from '@/view/ResumeForm';
 
 // 라우터 설정
 const router = createBrowserRouter([
@@ -60,6 +61,10 @@ const router = createBrowserRouter([
   {
     path: PATH.AUTH,
     element: <Auth />,
+  },
+  {
+    path: PATH.RESUME_CREATE_FORM,
+    element: <ResumeForm />,
   },
   {
     path: '*',

--- a/src/router/Path.ts
+++ b/src/router/Path.ts
@@ -5,6 +5,7 @@ export const PATH = {
   POSTING: '/posting', // 전체 공고
   DASHBOARD: '/dashboard', // 통계 분석
   RESUME: '/resume', // 이력서 관리
+  RESUME_CREATE_FORM: '/resume/write', // 공통 이력서 양식으로 작성
   SCRAP: '/scrap', // 공고 좋아요
   NOTIFICATION: '/notification', // 알림
   SETTINGS: '/settings', // 계정 설정

--- a/src/store/useResumeItemMenuStore.tsx
+++ b/src/store/useResumeItemMenuStore.tsx
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface MenuState {
+  isAnyMenuOpen: boolean;
+  setIsAnyMenuOpen: (open: boolean) => void;
+}
+
+export const useResumeItemMenuStore = create<MenuState>((set) => ({
+  isAnyMenuOpen: false,
+  setIsAnyMenuOpen: (open) => set({ isAnyMenuOpen: open }),
+}));

--- a/src/type/ResumeFormType.ts
+++ b/src/type/ResumeFormType.ts
@@ -1,0 +1,60 @@
+export type AdditionalInfoType = '수상' | '자격증' | '활동' | undefined;
+export type LanguageLevelType =
+  | '유창함'
+  | '고급 비즈니스 레벨'
+  | '비즈니스 레벨'
+  | '일상 회화'
+  | undefined;
+
+export interface Period {
+  startDate: Date | null;
+  endDate: Date | null;
+}
+
+export interface WorkHistory {
+  companyName: string;
+  position: string;
+  period: Period;
+  description: string;
+}
+
+export interface Education {
+  name: string;
+  period: Period;
+  description: string;
+}
+
+export interface AdditionalInfo {
+  name: string;
+  date: Date | null;
+  type: AdditionalInfoType;
+  description: string;
+}
+
+export interface Test {
+  testName: string;
+  date: Date | null;
+  score: string;
+}
+
+export interface Language {
+  name: string;
+  level: LanguageLevelType;
+  test: Test[];
+}
+
+export interface Portfolio {
+  name: string;
+  url: string;
+}
+
+export interface ResumeFormInputs {
+  title: string;
+  profile: string;
+  workHistory: WorkHistory[];
+  education: Education[];
+  skill: string;
+  additionalInfo: AdditionalInfo[];
+  language: Language[];
+  portfolio: Portfolio[];
+}

--- a/src/view/Resume.tsx
+++ b/src/view/Resume.tsx
@@ -3,25 +3,19 @@ import ResumeItem from '@/components/resume/ResumeItem';
 
 const Resume = () => {
   return (
-    <div className="w-full bg-white h-dvh overflow-scroll">
+    <div className="w-full bg-white min-h-dvh">
       <div className="w-full p-14">
         <h1 className="text-3xl">이력서 목록</h1>
-        <div className="grid grid-cols-3 w-full gap-12 my-5">
+        <div className="grid grid-cols-3 w-full gap-12 my-14">
           <CreateButton
             icon="+"
             title="새 이력서 작성"
             sub="취업모아 이력서로 서류 합격률 2배 UP!"
+            path="/resume/write"
           />
           <ResumeItem title="unknown" memo="unknown" updatedAt="26.03.11" />
           <ResumeItem title="unknown" updatedAt="" />
-          <div className="w-full h-75 bg-blue-500 rounded-2xl"></div>
-          <div className="w-full h-75 bg-blue-500 rounded-2xl"></div>
-          <div className="w-full h-75 bg-blue-500 rounded-2xl"></div>
-          <div className="w-full h-75 bg-blue-500 rounded-2xl"></div>
-          <div className="w-full h-75 bg-blue-500 rounded-2xl"></div>
-          <div className="w-full h-75 bg-blue-500 rounded-2xl"></div>
-          <div className="w-full h-75 bg-blue-500 rounded-2xl"></div>
-          <div className="w-full h-75 bg-blue-500 rounded-2xl"></div>
+          <ResumeItem title="unknown" updatedAt="" />
         </div>
       </div>
     </div>

--- a/src/view/ResumeForm.tsx
+++ b/src/view/ResumeForm.tsx
@@ -1,0 +1,78 @@
+import { useForm, FormProvider } from 'react-hook-form';
+import ResumeFormTopbar from '@/components/resumeForm/ResumeFormTopbar';
+import type { ResumeFormInputs } from '@/type/ResumeFormType';
+import ResumeFormProfile from '@/components/resumeForm/ResumeFormProfile';
+import ResumeFormWorkHistory from '@/components/resumeForm/ResumeFormWorkHistory';
+import ResumeFormEducation from '@/components/resumeForm/ResumeFormEducation';
+import ResumeFormAdditionalInfo from '@/components/resumeForm/ResumeFormAdditionalInfo';
+import ResumeFormSkill from '@/components/resumeForm/ResumeFormSkill';
+import ResumeFormLanguage from '@/components/resumeForm/ResumeFormLanguage';
+import ResumeFormWorkPortfolio from '@/components/resumeForm/ResumeFormPortfolio';
+
+const ResumeForm = () => {
+  const resume = useForm<ResumeFormInputs>({
+    defaultValues: {
+      title: '',
+      profile: '',
+      workHistory: [
+        {
+          companyName: '',
+          position: '',
+          period: { startDate: null, endDate: null },
+          description: '',
+        },
+      ],
+      education: [
+        {
+          name: '',
+          period: { startDate: null, endDate: null },
+          description: '',
+        },
+      ],
+      additionalInfo: [
+        {
+          name: '',
+          date: null,
+          type: undefined,
+          description: '',
+        },
+      ],
+      skill: '',
+      language: [
+        {
+          name: '',
+          level: undefined,
+          test: [
+            {
+              testName: '',
+              date: null,
+            },
+          ],
+        },
+      ],
+      portfolio: [{ name: '', url: '' }],
+    },
+  });
+  return (
+    <div className="w-full h-dvh overflow-hidden">
+      <FormProvider {...resume}>
+        <ResumeFormTopbar />
+        <div className="w-full h-full bg-black/5 overflow-y-scroll">
+          <form className="mx-50 mt-15 mb-45 p-15 bg-white">
+            <ResumeFormProfile />
+            <ResumeFormWorkHistory />
+            <ResumeFormSkill />
+            <ResumeFormEducation />
+            <div className="flex gap-6">
+              <ResumeFormAdditionalInfo />
+              <ResumeFormLanguage />
+            </div>
+            <ResumeFormWorkPortfolio />
+          </form>
+        </div>
+      </FormProvider>
+    </div>
+  );
+};
+
+export default ResumeForm;


### PR DESCRIPTION
## 개요 (Summary)

- @99jc 님이 구현하신 이력서 관리 페이지를 배포합니다.

## 관련 이슈 / 기획 문서

- 관련 이슈: #27 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 이력서 작성 폼 추가: 프로필, 경력, 교육, 기술, 언어(시험 항목 포함), 수상/자격증, 포트폴리오 섹션
  * 텍스트 입력 필드에 문자 수 카운터 추가

* **버그 수정**
  * 이력서 항목의 메뉴 상호작용 개선

* **스타일**
  * 레이아웃 간격 및 컨테이너 높이 조정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->