### PR TITLE
🛠️ Fix : 공고 입력 폼에서 파싱하기 바 보이게 수정

### DIFF
--- a/src/components/jobPostForm/CrawlBar.tsx
+++ b/src/components/jobPostForm/CrawlBar.tsx
@@ -16,7 +16,12 @@ const STYLES = {
     'px-[13px] py-[6px] text-[12px] bg-[#4f46e5] text-white rounded-[6px] border border-transparent font-medium cursor-pointer hover:bg-[#4338ca] transition-colors',
 };
 
-const CrawlBar = ({ url, onUrlChange, onParse, isParsing = false }: CrawlBarProps) => {
+const CrawlBar = ({
+  url = '',
+  onUrlChange = () => {},
+  onParse = () => {},
+  isParsing = false,
+}: CrawlBarProps) => {
   return (
     <div className={STYLES.container}>
       <span className={STYLES.iconWrapper}>

--- a/src/components/jobPostForm/JobModal.tsx
+++ b/src/components/jobPostForm/JobModal.tsx
@@ -53,6 +53,9 @@ interface JobModalProps {
 const JobModal = ({ isOpen, onClose }: JobModalProps) => {
   const [isAlwaysRecruit, setIsAlwaysRecruit] = useState(false);
 
+  const [crawlUrl, setCrawlUrl] = useState('');
+  const [isParsing, setIsParsing] = useState(false);
+
   const {
     register,
     handleSubmit,
@@ -90,6 +93,7 @@ const JobModal = ({ isOpen, onClose }: JobModalProps) => {
       source_site_name: null,
     });
     setIsAlwaysRecruit(false);
+    setCrawlUrl('');
   };
 
   const handleAlwaysRecruitChange = (checked: boolean) => {
@@ -102,6 +106,19 @@ const JobModal = ({ isOpen, onClose }: JobModalProps) => {
   const handleClose = () => {
     onClose();
     handleReset();
+  };
+
+  const handleParse = () => {
+    if (!crawlUrl.trim()) return;
+    setIsParsing(true);
+    // 파싱 기능 api 연동 전
+    setTimeout(() => {
+      setIsParsing(false);
+      alert(
+        'URL 파싱 기능은 아직 준비 중입니다. 입력하신 URL을 공고 URL 필드에 자동으로 채워드렸습니다.',
+      );
+      setValue('source_url', crawlUrl);
+    }, 1000);
   };
 
   const onSubmit = (data: JobPostFields) => {
@@ -132,7 +149,12 @@ const JobModal = ({ isOpen, onClose }: JobModalProps) => {
           </button>
         </div>
 
-        <CrawlBar />
+        <CrawlBar
+          url={crawlUrl}
+          onUrlChange={setCrawlUrl}
+          onParse={handleParse}
+          isParsing={isParsing}
+        />
 
         <div className={STYLES.topSection}>
           <Controller


### PR DESCRIPTION
## 제목

공고 입력 폼에서 파싱하기 바 보이게 수정 

## 개요 (Summary)

- 파싱하기 바를 구현했는데 현재 화면이 보이지 않아 코드를 수정하여 화면에 보이게 했습니다.

## 관련 이슈 / 기획 문서

- 관련 이슈: 
- close

---

## 1. 변경 유형 (Type)

- [ ] 기능 추가 (Feature)
- [x] 버그 수정 (Bug fix)
- [ ] 리팩터링 (Refactor)
- [ ] 스타일/UI 수정 (Style)
- [ ] 문서 (Docs)
- [ ] 인프라/배포 (Infra/DevOps)
- [ ] 기타 (Other, 아래에 설명)

---

## 2. 프론트엔드 상세 내용 (What changed)

- [ ] 페이지 추가/변경 (`/login`, `/dashboard`, `/resume` 등)
- [ ] 공통 컴포넌트 추가/변경
- [ ] API 연동 (엔드포인트: )
- [ ] 상태 관리 (전역/로컬)
- [ ] 라우팅 변경
- [ ] 스타일/레이아웃

## 변경 요약:

## 3. UI 스크린샷 / 영상

- 변경 전
- 
<img width="970" height="815" alt="image" src="https://github.com/user-attachments/assets/017d2594-d2ab-40a3-964c-ea6c68e648a6" />


- 변경 후
<img width="954" height="818" alt="image" src="https://github.com/user-attachments/assets/85c6d719-08a8-4b57-bc07-339234e43e7a" />


---

## 4. 브라우저 / 환경 체크

- [x] Chrome
- [ ] Safari
- [ ] 모바일 반응형

---

## 기타 (Notes)
