### PR TITLE
🛠️ Fix: pdf업로드후 저장 시 오류 수정

### DIFF
--- a/src/api/ResumeForm.ts
+++ b/src/api/ResumeForm.ts
@@ -1,4 +1,9 @@
-import type { GetResumeById, ResumeFormData, ResumeInfo } from '@/types/ResumeFormType';
+import type {
+  GetResumeById,
+  ResumeFormData,
+  ResumeInfo,
+  UploadResult,
+} from '@/types/ResumeFormType';
 import api from './Axios';
 
 export const createResume = async (data: ResumeFormData): Promise<ResumeInfo> => {
@@ -31,7 +36,7 @@ export const duplicateResume = async (resumeId: string) => {
   return response.data;
 };
 
-export const uploadPortfolio = async (file: File): Promise<string> => {
+export const uploadPortfolio = async (file: File): Promise<UploadResult> => {
   const formData = new FormData();
   formData.append('file', file);
   const response = await api.post('/portfolios/upload', formData, {

--- a/src/components/resumeForm/ResumeFormDropzone.tsx
+++ b/src/components/resumeForm/ResumeFormDropzone.tsx
@@ -53,7 +53,10 @@ const DropzoneBox = ({ value, onChange, index }: DropzoneBoxProps) => {
 
   return portfolio.file || portfolio.fileUrl ? (
     <div className="group relative p-10 w-full my-3 text-center justify-center border rounded-2xl hover:bg-black/10 border-black/20">
-      <ResumeFormPortfolioItem name={portfolio.name} file={portfolio.file} />
+      <ResumeFormPortfolioItem
+        name={portfolio.file ? portfolio.file.name : portfolio.name}
+        file={portfolio.file}
+      />
       <button
         type="button"
         onClick={() => {}}

--- a/src/components/resumeForm/ResumeFormTopbar.tsx
+++ b/src/components/resumeForm/ResumeFormTopbar.tsx
@@ -50,7 +50,7 @@ const ResumeFormTopbar = () => {
         data.portfolio.map(async (p) => {
           if (p.file instanceof File) {
             const response = await uploadPortfolio.mutateAsync(p.file);
-            return { ...p, fileUrl: response };
+            return { ...p, fileUrl: response.fileUrl };
           } else {
             return p;
           }

--- a/src/hooks/resume.ts
+++ b/src/hooks/resume.ts
@@ -14,6 +14,7 @@ export const useSaveResume = (resumeId: string | undefined) => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (formData: ResumeFormData) => {
+      console.log(formData);
       if (!resumeId) {
         const response = await createResume(formData);
         return response;

--- a/src/types/ResumeFormType.ts
+++ b/src/types/ResumeFormType.ts
@@ -97,4 +97,9 @@ export interface GetResumeById {
   createdAt: string;
 }
 
+export interface UploadResult {
+  message: string;
+  fileUrl: string;
+}
+
 export type pdfType = File | string | null | undefined;


### PR DESCRIPTION
## 제목

 pdf업로드후 저장 시 오류 수정

## 개요 (Summary)

- pdf업로드 후 이력서 저장 시 500오류가 발생하는 에러를 수정했습니다.

## 관련 이슈 / 기획 문서

- 관련 이슈: #63
- close

---

## 1. 변경 유형 (Type)

- [ ] 기능 추가 (Feature)
- [x] 버그 수정 (Bug fix)
- [ ] 리팩터링 (Refactor)
- [ ] 스타일/UI 수정 (Style)
- [ ] 문서 (Docs)
- [ ] 인프라/배포 (Infra/DevOps)
- [ ] 기타 (Other, 아래에 설명)

---

## 2. 프론트엔드 상세 내용 (What changed)

- [ ] 페이지 추가/변경 (`/login`, `/dashboard`, `/resume` 등)
- [ ] 공통 컴포넌트 추가/변경
- [ ] API 연동 (엔드포인트: )
- [ ] 상태 관리 (전역/로컬)
- [ ] 라우팅 변경
- [ ] 스타일/레이아웃

## 변경 요약:

---

## 3. UI 스크린샷 / 영상

<!-- 변경 전후 캡처 또는 GIF를 첨부해주세요. UI 변경이 없으면 생략 가능 -->

| Before | After |
| ------ | ----- |
|        |       |

---

## 4. 브라우저 / 환경 체크

- [x] Chrome
- [ ] Safari
- [ ] 모바일 반응형

---

## 기타 (Notes)

- merge 전에 전체적으로 다시한번 코드 래빗으로 검사 돌려주시면 감사하겠습니다.
