### PR TITLE
✨ Feat : 구글 / 일반 회원 구분 및 구글 회원 수정 프로필, 비밀번호 수정 불가

### DIFF
--- a/src/components/Auth/Login/Login.tsx
+++ b/src/components/Auth/Login/Login.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { PATH } from '@/router/Path';
 import LoginForm from './LoginForm';
 import PasswordResetForm from './PasswordResetForm';
-import { loginApi, googleCredentialLoginApi } from '@/api/Auth'; // 👈 구글 api 추가
+import { loginApi, googleCredentialLoginApi } from '@/api/Auth';
 import type { LoginField } from '@/types/Auth';
 import { useAuthStore } from '@/store/useAuthStore';
 
@@ -20,7 +20,6 @@ const Login: React.FC<LoginProps> = ({ onSwitchRegister }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [errorMsg, setErrorMsg] = useState('');
 
-  // 1. 일반 이메일 로그인 처리
   const handleLogin = async (data: LoginField) => {
     setIsLoading(true);
     setErrorMsg('');
@@ -33,6 +32,7 @@ const Login: React.FC<LoginProps> = ({ onSwitchRegister }) => {
           name: response.user.name,
           email: response.user.email,
           profile_image_url: response.user.profile_image_url,
+          provider: response.user.provider || 'local',
         });
         navigate(PATH.ROOT);
       }
@@ -67,6 +67,7 @@ const Login: React.FC<LoginProps> = ({ onSwitchRegister }) => {
         name: response.user.name,
         email: response.user.email,
         profile_image_url: response.user.profile_image_url,
+        provider: response.user.provider || 'google',
       });
       navigate(PATH.ROOT);
     } catch {

--- a/src/components/setting/UserAction.tsx
+++ b/src/components/setting/UserAction.tsx
@@ -112,7 +112,6 @@ const UserAction: React.FC<UserActionProps> = ({
         )}
       </div>
 
-      {/* 로그아웃 섹션 */}
       <div className="flex items-center justify-between p-6 rounded-2xl border border-gray-100 bg-gray-50/50">
         <div>
           <div className="text-[15px] font-bold text-gray-800">로그아웃</div>
@@ -128,7 +127,6 @@ const UserAction: React.FC<UserActionProps> = ({
         </button>
       </div>
 
-      {/* 회원탈퇴 섹션 */}
       <div className="flex items-center justify-between p-6 rounded-2xl border border-red-100 bg-red-50/30">
         <div>
           <div className="text-[15px] font-bold text-red-500">회원탈퇴</div>

--- a/src/components/setting/UserInfo.tsx
+++ b/src/components/setting/UserInfo.tsx
@@ -28,13 +28,16 @@ const UserInfo: React.FC<UserInfoProps> = ({
     e.target.value = '';
   };
 
-  // ✨ 대소문자 무관하게 안전하게 구글 계정 판별
   const isGoogle = provider?.toLowerCase() === 'google';
 
   return (
     <div className="flex flex-col sm:flex-row items-center sm:items-start gap-8 pb-10 mb-10 border-b border-gray-100">
       <div className="relative group shrink-0">
-        <div className="flex items-center justify-center w-28 h-28 rounded-full bg-btn-point text-[36px] font-black text-white shadow-md overflow-hidden transition-transform group-hover:scale-[1.02]">
+        <div
+          className={`flex items-center justify-center w-28 h-28 rounded-full bg-btn-point text-[36px] font-black text-white shadow-md overflow-hidden transition-transform ${
+            !isGoogle ? 'group-hover:scale-[1.02]' : ''
+          }`}
+        >
           {profileImageUrl ? (
             <img src={profileImageUrl} alt="Profile" className="w-full h-full object-cover" />
           ) : (
@@ -42,29 +45,33 @@ const UserInfo: React.FC<UserInfoProps> = ({
           )}
         </div>
 
-        <div className="absolute inset-0 bg-black/40 backdrop-blur-[2px] rounded-full opacity-0 group-hover:opacity-100 flex flex-col items-center justify-center gap-2 transition-all duration-200">
-          <button
-            onClick={() => fileInputRef.current?.click()}
-            className="text-white text-[13px] font-bold hover:text-purple-200 transition-colors"
-          >
-            이미지 변경
-          </button>
-          {profileImageUrl && (
-            <button
-              onClick={onDeleteImage}
-              className="text-red-300 text-[13px] font-bold hover:text-red-400 transition-colors"
-            >
-              삭제
-            </button>
-          )}
-        </div>
-        <input
-          type="file"
-          accept="image/*"
-          className="hidden"
-          ref={fileInputRef}
-          onChange={handleFileChange}
-        />
+        {!isGoogle && (
+          <>
+            <div className="absolute inset-0 bg-black/40 backdrop-blur-[2px] rounded-full opacity-0 group-hover:opacity-100 flex flex-col items-center justify-center gap-2 transition-all duration-200">
+              <button
+                onClick={() => fileInputRef.current?.click()}
+                className="text-white text-[13px] font-bold hover:text-purple-200 transition-colors"
+              >
+                이미지 변경
+              </button>
+              {profileImageUrl && (
+                <button
+                  onClick={onDeleteImage}
+                  className="text-red-300 text-[13px] font-bold hover:text-red-400 transition-colors"
+                >
+                  삭제
+                </button>
+              )}
+            </div>
+            <input
+              type="file"
+              accept="image/*"
+              className="hidden"
+              ref={fileInputRef}
+              onChange={handleFileChange}
+            />
+          </>
+        )}
       </div>
 
       <div className="flex-1 min-w-0 text-center sm:text-left pt-2">


### PR DESCRIPTION
## 개요 (Summary)

- 로그인 시 계정 설정에 일반회원으로 되어있는 뱃지를 구글 / 일반 회원으로 구분하는 뱃지로 수정하였습니다.
- 추가로 구글 회원은 비밀번호 변경 비활성화, 프로필 이미지 변경이 불가하게 수정하였습니다.

## 관련 이슈 / 기획 문서

- 관련 이슈 #74 

---

## 1. 변경 유형 (Type)

- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug fix)
- [ ] 리팩터링 (Refactor)
- [ ] 스타일/UI 수정 (Style)
- [ ] 문서 (Docs)
- [ ] 인프라/배포 (Infra/DevOps)
- [ ] 기타 (Other, 아래에 설명)

## UI
<img width="771" height="748" alt="image" src="https://github.com/user-attachments/assets/a185a825-b3fa-484f-bf4f-e8b160dca0fb" />

<img width="763" height="811" alt="image" src="https://github.com/user-attachments/assets/dbf3ae67-5300-4983-aa5e-d81dcbd28eed" />
