### PR TITLE
🛠️ Fix : 조회수api와연동

### DIFF
--- a/src/api/Posting.ts
+++ b/src/api/Posting.ts
@@ -92,11 +92,13 @@ export const manualSave = async (data: ManualSaveRequest): Promise<{ job: Backen
 };
 
 // 조회수 증가 API
-export const incrementViewCount = async (jobId: string | number): Promise<void> => {
+export const incrementViewCount = async (jobId: string | number): Promise<number | null> => {
   try {
-    await api.patch(`/jobs/${jobId}/view`);
+    const response = await api.patch(`/jobs/${jobId}/view`);
+    return response.data.viewCount;
   } catch (error: unknown) {
     console.error('조회수 증가 실패:', error);
+    return null;
   }
 };
 

--- a/src/store/usePostingStore.ts
+++ b/src/store/usePostingStore.ts
@@ -91,7 +91,7 @@ interface PostingState {
   parseJobUrl: (url: string) => Promise<Record<string, unknown>>;
   saveParsedJob: (data: ManualSaveRequest) => Promise<void>;
   updateCommentCount: (jobId: string | number, delta: number) => void;
-  updateViewCount: (jobId: string | number) => void;
+  updateViewCount: (jobId: string | number, viewCount: number) => void;
   resetFilters: () => void;
 }
 
@@ -323,12 +323,10 @@ export const usePostingStore = create<PostingState>()(
         }));
       },
 
-      updateViewCount: (jobId: string | number) => {
+      updateViewCount: (jobId: string | number, viewCount: number) => {
         set((state) => ({
           postings: state.postings.map((job) =>
-            String(job.id) === String(jobId)
-              ? { ...job, viewCount: (job.viewCount || 0) + 1 }
-              : job,
+            String(job.id) === String(jobId) ? { ...job, viewCount } : job,
           ),
         }));
       },

--- a/src/view/Posting.tsx
+++ b/src/view/Posting.tsx
@@ -59,11 +59,13 @@ const Posting = () => {
     return postings.find((job) => String(job.id) === String(selectedJobId)) || null;
   }, [postings, selectedJobId]);
 
-  const handleDetailOpen = (job: ExtendedJobPosting) => {
+  const handleDetailOpen = async (job: ExtendedJobPosting) => {
     setSelectedJobId(job.id);
     setIsDetailModalOpen(true);
-    updateViewCount(job.id);
-    incrementViewCount(job.id);
+    const viewCount = await incrementViewCount(job.id);
+    if (viewCount !== null) {
+      updateViewCount(job.id, viewCount);
+    }
   };
 
   const handleDetailClose = () => {


### PR DESCRIPTION
## 제목

<!-- 조회수api와연동-->

## 개요 (Summary)

- 변경된 api에 맞추어 프론트 코드를 수정하였습니다.

## 관련 이슈 / 기획 문서

- 관련 이슈: #(번호)
- close

---

## 1. 변경 유형 (Type)

- [ ] 기능 추가 (Feature)
- [x] 버그 수정 (Bug fix)
- [ ] 리팩터링 (Refactor)
- [ ] 스타일/UI 수정 (Style)
- [ ] 문서 (Docs)
- [ ] 인프라/배포 (Infra/DevOps)
- [ ] 기타 (Other, 아래에 설명)

---

## 2. 프론트엔드 상세 내용 (What changed)

- [ ] 페이지 추가/변경 (`/login`, `/dashboard`, `/resume` 등)
- [ ] 공통 컴포넌트 추가/변경
- [ ] API 연동 (엔드포인트: )
- [ ] 상태 관리 (전역/로컬)
- [ ] 라우팅 변경
- [ ] 스타일/레이아웃

## 변경 요약:

---

## 3. UI 스크린샷 / 영상

<!-- 변경 전후 캡처 또는 GIF를 첨부해주세요. UI 변경이 없으면 생략 가능 -->

| Before | After |
| ------ | ----- |
|        |       |

---

## 4. 브라우저 / 환경 체크

- [x] Chrome
- [ ] Safari
- [ ] 모바일 반응형

---

## 기타 (Notes)

- 이제 로그인한 사용자는 동일한 아이디, 공고일 경우, 비로그인 회원의 경우 ip당 동일한 공고일 경우 조회수가 1번만 올라가도록 수정되었습니다.
