### PR TITLE
🛠️ Fix : 조회수로직중복제거

### DIFF
--- a/src/components/Posting/PostingActionButtons.tsx
+++ b/src/components/Posting/PostingActionButtons.tsx
@@ -5,7 +5,6 @@ import Button from '@/components/common/UI/Button';
 import { ExternalLink, Search, Bookmark } from 'lucide-react';
 import ConfirmModal from '@/components/common/UI/ConfirmModal';
 import { toggleScrap } from '@/api/Scrap';
-import { incrementViewCount } from '@/api/Posting';
 
 interface PostingActionButtonsProps {
   job: JobPosting;
@@ -30,7 +29,6 @@ const PostingActionButtons: React.FC<PostingActionButtonsProps> = ({
   // 상세보기 클릭 시 조회수 증가 및 상세 모달 오픈
   const handleDetailClick = (e: React.MouseEvent) => {
     e.stopPropagation();
-    incrementViewCount(job.id);
     onDetailClick();
   };
 

--- a/src/components/Posting/PostingCard.tsx
+++ b/src/components/Posting/PostingCard.tsx
@@ -9,7 +9,6 @@ import { getJobComments } from '@/api/Comment';
 import type { RawCommentData } from './Comment/useJobComment';
 import { usePostingStore } from '@/store/usePostingStore';
 import { toggleScrap } from '@/api/Scrap';
-import { incrementViewCount } from '@/api/Posting';
 import ConfirmModal from '@/components/common/UI/ConfirmModal';
 import { useToastStore } from '@/store/useToastStore';
 import { useQueryClient } from '@tanstack/react-query';
@@ -43,9 +42,6 @@ const PostingCard = ({ posting, isScrapped, isApplied, onScrap, onDetail }: Post
   const queryClient = useQueryClient();
 
   const handleCardClick = () => {
-    if (posting.sourceType !== 'manual') {
-      incrementViewCount(posting.id);
-    }
     onDetail(posting);
   };
 


### PR DESCRIPTION
## 제목

<!-- 조회수로직중복제거-->

## 개요 (Summary)

- 조회수 로직이 여러번 중복 사용되어 2번씩 조회수가 올라가고, 1번이 아닌 계속 조회수가 올라가는 현상 수정

## 관련 이슈 / 기획 문서

- 관련 이슈: #(번호)
- close

---

## 1. 변경 유형 (Type)

- [ ] 기능 추가 (Feature)
- [x] 버그 수정 (Bug fix)
- [ ] 리팩터링 (Refactor)
- [ ] 스타일/UI 수정 (Style)
- [ ] 문서 (Docs)
- [ ] 인프라/배포 (Infra/DevOps)
- [ ] 기타 (Other, 아래에 설명)

---

## 2. 프론트엔드 상세 내용 (What changed)

- [ ] 페이지 추가/변경 (`/login`, `/dashboard`, `/resume` 등)
- [ ] 공통 컴포넌트 추가/변경
- [ ] API 연동 (엔드포인트: )
- [ ] 상태 관리 (전역/로컬)
- [ ] 라우팅 변경
- [ ] 스타일/레이아웃

## 변경 요약:

---

## 3. UI 스크린샷 / 영상

<!-- 변경 전후 캡처 또는 GIF를 첨부해주세요. UI 변경이 없으면 생략 가능 -->

| Before | After |
| ------ | ----- |
|        |       |

---

## 4. 브라우저 / 환경 체크

- [x] Chrome
- [ ] Safari
- [ ] 모바일 반응형

---

## 기타 (Notes)

- 리뷰어가 알면 좋을 추가 맥락이나 TODO가 있다면 적어주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Changes**
  * 게시물 상세보기 버튼 클릭 시 뷰 카운트 증가 기능 제거
  * 게시물 카드 클릭 시 조회수 카운팅 로직 제거

<!-- end of auto-generated comment: release notes by coderabbit.ai -->